### PR TITLE
Replace "round" by "floor" when calculating months

### DIFF
--- a/YLMoment/YLMoment+RelativeTime.m
+++ b/YLMoment/YLMoment+RelativeTime.m
@@ -95,7 +95,7 @@ static NSString * const kYLMomentRelativeTimeStringTable = @"YLMomentRelativeTim
   }
   else if (days < 345) {
     formattedString = [localBundle localizedStringForKey:@"MM" value:@"%d months" table:kYLMomentRelativeTimeStringTable];
-    unit            = round(days / 30);
+    unit            = floor(days / 30);
   }
   else if (years == 1) {
     formattedString = [localBundle localizedStringForKey:@"y" value:@"a year" table:kYLMomentRelativeTimeStringTable];


### PR DESCRIPTION
I think it would look better using the floor function in this context than the round function because the amount of months past is still not achieved when the round function rounds up.

For example:

double days = 50.0f;

// Using round
int unit = round( days / 30 );    /// Returns 2 months passed, it's wrong

// Using floor
int unit = floor( days / 30 );    /// Returns 1 month passed, it's correct